### PR TITLE
Update Gruntfile.js

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -37,7 +37,11 @@ module.exports = function (grunt) {
       }
     },
     qunit: {
-      files: ['test/**/*.html']
+      all: {
+        options: {
+          urls: ['http://localhost:9000/test/<%%= pkg.name %>.html']
+        }
+      }
     },
     jshint: {
       gruntfile: {
@@ -94,6 +98,6 @@ module.exports = function (grunt) {
 
   // Default task.
   grunt.registerTask('default', ['jshint', 'qunit', 'clean', 'concat', 'uglify']);
-  grunt.registerTask('test', ['jshint', 'qunit']);
   grunt.registerTask('server', ['connect', 'watch']);
+  grunt.registerTask('test', ['jshint', 'connect', 'qunit']);
 };


### PR DESCRIPTION
I wasn't able to get the original configuration working out of the box for doing a grunt test.
Reason was that phantomjs timed out when qunit was configured with file patterns for the tests to run.
The fix is simply to configure qunit with urls for the files to test. 
See also https://github.com/gruntjs/grunt-contrib-qunit/issues/15
