### PR TITLE
Adds /bower_components/ and dist to .gitignore.

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,1 +1,3 @@
 /node_modules/
+/bower_components/
+dist


### PR DESCRIPTION
Hi, thanks for making this awesome generator.  `dist` and package files are generally not kept in source history, so this seems like a sane default for me.
