### PR TITLE
Fixes package.json author/repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,9 @@
   ],
   "homepage": "https://github.com/yeoman/generator-jquery",
   "bugs": "https://github.com/yeoman/generator-jquery/issues",
-  "author": {
-    "name": "Pascal Hartig",
-    "email": "phartig@rdrei.net",
-    "url": "https://github.com/passy"
-  },
+  "author": "The Yeoman Team",
   "main": "app/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/yeoman/generator-jquery.git"
-  },
+  "repository": "yeoman/generator-jquery",
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
The actual author/repository metadata does not reflect the **official** status of the generator.

It is causing places that relies on this data to not display the generator as an official one, here is how it looks like in the website:

![](http://i.imgur.com/ndv7AMS.png)

And here is how it should look like (with a mustache, like the other official ones):

![](http://i.imgur.com/p8DIuHn.png)

I'm not sure if you have tried to keep some credits to Pascal but if that is the case I'm sure there are better ways of doing it :smile: 

This PR fixes the metadata, using the same standard as found in generator-angular, etc
