### PR TITLE
Move `appname` definition to the right place

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -41,6 +41,7 @@ module.exports = yeoman.generators.Base.extend({
 
       // For easier access in the templates.
       this.slugname = this._.slugify(props.name);
+      this.camelname = this._.camelize(props.name);
 
       cb();
     }.bind(this));
@@ -107,8 +108,6 @@ module.exports = yeoman.generators.Base.extend({
 
     this.prompt(prompts, function (props) {
       this.props = props;
-      // For easier access in the templates.
-      this.camelname = this._.camelize(props.name);
       cb();
     }.bind(this));
   },


### PR DESCRIPTION
Fixes #38. `this.camelname` was being set before prompting for it, and thus resolving to an empty string. The bug was introduced with https://github.com/yeoman/generator-jquery/commit/968102f145bf5eb64a75455abce3f7c9b8b95da6.